### PR TITLE
Quick fix for dnspython == version 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dnspython==1.16.0
+dnspython==2.0.0


### PR DESCRIPTION
$ pip3 install -r requirements.txt
Requirement already satisfied: dnspython==2.0.0 in /usr/local/lib/python3.8/site-packages (from -r requirements.txt (line 1)) (2.0.0)